### PR TITLE
Add example description to JS warnings

### DIFF
--- a/lib/dekiru/capybara/matchers.rb
+++ b/lib/dekiru/capybara/matchers.rb
@@ -2,6 +2,10 @@ module Dekiru
   module Capybara
     module Matchers
       class JsNoErrorMatcher
+        def initialize(example_description)
+          @example_description = example_description
+        end
+
         def matches?(page_or_logs)
           logs = if page_or_logs.respond_to?(:driver)
                    page_or_logs.driver.browser.logs.get(:browser)
@@ -9,7 +13,7 @@ module Dekiru
                    page_or_logs
                  end
           logs.find_all { |log| log.level == 'WARNING' }.each do |log|
-            STDERR.puts 'WARN: javascript warning'
+            STDERR.puts "WARN: javascript warning in #{@example_description}"
             STDERR.puts log.message
           end
 
@@ -27,7 +31,11 @@ module Dekiru
       end
 
       def have_no_js_errors
-        JsNoErrorMatcher.new
+        # NOTE: Extract "\"displays tooltip\" (./spec/system/my_awesome_spec.rb:101)"
+        # From "#<RSpec::ExampleGroups::Nested::Nested_4::Nested_4 \"displays tooltip\" (./spec/system/my_awesome_spec.rb:101)>"
+        example_description = self.inspect.split(' ', 2).last.chop
+
+        JsNoErrorMatcher.new(example_description)
       end
     end
   end


### PR DESCRIPTION
Output example:

```
WARN: javascript warning in "displays tooltip" (./spec/system/my_awesome_spec.rb:101)
http://127.0.0.1:53186/packs-test/js/application-1237f3764f27da97575a.js 125177:12 "[BootstrapVue warn]: tooltip - The provided target is no valid HTML element."
```