### PR TITLE
[review] Dekiru::TransactionProvider を追加

### DIFF
--- a/lib/dekiru.rb
+++ b/lib/dekiru.rb
@@ -4,6 +4,7 @@ require 'dekiru/helper'
 require 'dekiru/data_migration_operator'
 require 'dekiru/mail_security_interceptor'
 require 'dekiru/camelize_hash'
+require 'dekiru/transaction_provider'
 
 require 'active_support'
 require 'active_support/all'
@@ -20,11 +21,12 @@ module Dekiru
   end
 
   class Configuration
-    attr_accessor :mail_security_hook, :maintenance_script_directory
+    attr_accessor :mail_security_hook, :maintenance_script_directory, :transaction_provider
 
     def initialize
       @mail_security_hook = false # default
       @maintenance_script_directory = 'scripts'
+      @transaction_provider = TransactionProvider.new
     end
   end
 end

--- a/lib/dekiru/data_migration_operator.rb
+++ b/lib/dekiru/data_migration_operator.rb
@@ -30,7 +30,7 @@ module Dekiru
       else
         raise NestedTransactionError if current_transaction_open?
 
-        @result = ActiveRecord::Base.transaction do
+        @result = transaction_provider.within_transaction do
           run(&block)
           log "Finished execution: #{title}"
           confirm?("\nAre you sure to commit?")
@@ -74,10 +74,6 @@ module Dekiru
     end
 
     private
-
-    def current_transaction_open?
-      ActiveRecord::Base.connection.current_transaction.open?
-    end
 
     def log(message)
       if @pb && !@pb.finished?
@@ -148,5 +144,11 @@ module Dekiru
         instance_eval(&block)
       end
     end
+
+    def transaction_provider
+      Dekiru.configuration.transaction_provider
+    end
+
+    delegate :current_transaction_open?, to: :transaction_provider
   end
 end

--- a/lib/dekiru/transaction_provider.rb
+++ b/lib/dekiru/transaction_provider.rb
@@ -1,0 +1,11 @@
+module Dekiru
+  class TransactionProvider
+    def within_transaction(&)
+      ActiveRecord::Base.transaction(&)
+    end
+
+    def current_transaction_open?
+      ActiveRecord::Base.connection.current_transaction.open?
+    end
+  end
+end


### PR DESCRIPTION
複数DBを扱うプロジェクトなどにおいて、トランザクションの発行周りをカスタマイズできるようにするため。